### PR TITLE
Add fs handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Out of the box Caddy performs case-sensitive path matching. When migrating from 
 ## Features
 
 * Global case-insensitive behavior via one directive
-* Two modes: `lower` (default) or full Unicode `fold`
+* Three modes: `lower` (default), Unicode `fold`, or filesystem canonical `fs`
 * Optional exclusion globs for paths that must remain case-sensitive
 * Adds `X-Original-URI` header preserving the pre-transform path
 
@@ -34,8 +34,10 @@ Or add to an existing `xcaddy build` command.
 
 example.com {
 		casefold {
-				# mode fold | lower (default lower)
+				# mode fold | lower | fs (default lower)
 				mode fold
+				# root only needed for fs mode (filesystem canonical casing)
+				# root /var/www/site
 				# one or more exclude patterns (path.Match globs)
 				exclude /api/CaseSensitive/*
 				exclude /media/*.ZIP
@@ -77,6 +79,7 @@ example.com {
 * Apply early: be sure to declare the `order casefold first` block so the path is transformed before other matchers evaluate.
 * Exclusions use Go's `path.Match` (wildcards `*`, `?`, character classes). They are evaluated against the full path (leading slash included).
 * `fold` mode uses Unicode case folding (ß → ss, Greek sigma handling, etc.). This may slightly increase allocations vs simple lowercase.
+* `fs` mode walks the filesystem for each incoming path to map segments to their actual on-disk casing (use sparingly; involves directory reads per request; consider caching behind a CDN). Requires `root`.
 * Only the path component is transformed; query string is untouched.
 * If downstream logic depends on the original casing, read the `X-Original-URI` header.
 

--- a/handler.go
+++ b/handler.go
@@ -2,7 +2,9 @@ package casefold
 
 import (
 	"net/http"
+	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/caddyserver/caddy/v2"
@@ -37,7 +39,13 @@ type Casefold struct {
 	// Mode selects the transformation applied to the path. Supported values:
 	//  - "lower" (default): simple ASCII + Unicode ToLower
 	//  - "fold": Unicode case folding (locale-independent)
+	//  - "fs": canonicalize each existing path segment to the actual filesystem casing
 	Mode string `json:"mode,omitempty"`
+
+	// Root is required for mode "fs" and denotes the filesystem root directory
+	// that request paths are resolved against for canonical casing. If empty
+	// when mode=fs, the middleware skips canonicalization.
+	Root string `json:"root,omitempty"`
 
 	// Exclude is an optional list of glob patterns (evaluated with path.Match)
 	// that, if any matches the original request path, will skip rewriting.
@@ -65,6 +73,19 @@ func (c *Casefold) Provision(ctx caddy.Context) error { //nolint:revive
 		c.fold = lowerCaser{}
 	case "fold":
 		c.fold = cases.Fold()
+	case "fs":
+		// handled dynamically in ServeHTTP; keep fold nil
+		if c.Root == "" {
+			ctx.Logger().Warn("fs mode enabled but root not set; skipping canonicalization")
+		} else {
+			// normalize root to absolute for safety
+			if !filepath.IsAbs(c.Root) {
+				abs, err := filepath.Abs(c.Root)
+				if err == nil {
+					c.Root = abs
+				}
+			}
+		}
 	default:
 		ctx.Logger().Warn("unknown casefold mode; defaulting to lower", zap.String("mode", c.Mode))
 		c.fold = lowerCaser{}
@@ -81,15 +102,93 @@ func (c *Casefold) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyh
 	if c.skip(orig) {
 		return next.ServeHTTP(w, r)
 	}
-	transformed := c.fold.String(orig)
+
+	mode := strings.ToLower(strings.TrimSpace(c.Mode))
+	transformed := orig
+	switch mode {
+	case "", "lower", "fold":
+		transformed = c.fold.String(orig)
+	case "fs":
+		canon, ok := c.canonicalFS(orig)
+		if ok {
+			transformed = canon
+		} else {
+			// fallback to original (no change) if not all segments resolved
+		}
+	}
+
 	if transformed != orig {
-		// Expose original path to downstream handlers (request) and client (response)
 		r.Header.Set("X-Original-URI", orig)
 		w.Header().Set("X-Original-URI", orig)
 		r.URL.Path = transformed
 		r.RequestURI = transformed
 	}
 	return next.ServeHTTP(w, r)
+}
+
+// canonicalFS attempts to replace each path segment with the actual casing
+// found on disk under Root. Returns (newPath, true) on success. If Root is empty,
+// a segment is missing, or a security check fails, returns original path, false.
+func (c *Casefold) canonicalFS(p string) (string, bool) {
+	if c.Root == "" {
+		return p, false
+	}
+	clean := path.Clean(p)
+	if !strings.HasPrefix(clean, "/") {
+		return p, false
+	}
+	if clean == "/" {
+		return p, false
+	}
+	segs := strings.Split(strings.TrimPrefix(clean, "/"), "/")
+	curDir := c.Root
+	// prevent traversal outside root: reject any segment with '..'
+	for _, s := range segs {
+		if s == ".." {
+			return p, false
+		}
+	}
+	built := make([]string, 0, len(segs))
+	for i, seg := range segs {
+		entries, err := os.ReadDir(curDir)
+		if err != nil {
+			return p, false
+		}
+		var matchName string
+		// first attempt exact match
+		for _, e := range entries {
+			name := e.Name()
+			if name == seg {
+				matchName = name
+				break
+			}
+		}
+		if matchName == "" {
+			// case-insensitive search
+			lowered := strings.ToLower(seg)
+			for _, e := range entries {
+				if strings.ToLower(e.Name()) == lowered {
+					matchName = e.Name()
+					break
+				}
+			}
+		}
+		if matchName == "" {
+			return p, false
+		}
+		built = append(built, matchName)
+		if i < len(segs)-1 { // descend only if not final segment
+			curDir = filepath.Join(curDir, matchName)
+			// optional: if it's not a dir we can stop early
+			fi, err := os.Stat(curDir)
+			if err != nil || !fi.IsDir() {
+				if i != len(segs)-1 {
+					return p, false
+				}
+			}
+		}
+	}
+	return "/" + strings.Join(built, "/"), true
 }
 
 // skip returns true if the path matches an exclude pattern.


### PR DESCRIPTION
This pull request introduces a new "fs" (filesystem canonicalization) mode to the `casefold` middleware, allowing incoming request paths to be rewritten to match the actual casing on disk. This is particularly useful for environments where path casing matters (e.g., case-sensitive filesystems) and consistency is required. The documentation and tests are updated to reflect and validate this new functionality.

**New Filesystem Canonicalization Mode:**

* Added a new `fs` mode to the `Casefold` handler, which rewrites request paths to match the actual casing of each segment as found on disk. This involves reading directory entries for each path segment and reconstructing the canonical path. (`handler.go`, `README.md`) [[1]](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087R42-R49) [[2]](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087L84-L86) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L14-R14) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L37-R40) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R82)
* Introduced a required `Root` configuration parameter for `fs` mode, specifying the filesystem root against which paths are resolved. This is validated and normalized during provisioning. (`handler.go`, `README.md`) [[1]](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087R42-R49) [[2]](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087R76-R88) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L37-R40) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R82)

**Code and Test Updates:**

* Modified the request handling logic to call the new `canonicalFS` method when `fs` mode is enabled, falling back to the original path if canonicalization fails. (`handler.go`)
* Added a new test `TestCasefoldFSMode` to verify that the handler correctly canonicalizes request paths to match the on-disk casing. (`handler_test.go`)
* Updated documentation to describe the new mode, its configuration, and usage caveats (e.g., performance implications and the need for caching behind a CDN). (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L14-R14) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L37-R40) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R82)

These changes make the middleware more flexible and robust for deployments requiring strict path casing alignment with the filesystem.